### PR TITLE
fix: dn_execute_compose.bash env var fail to export to calling script

### DIFF
--- a/dockerized-norlab-scripts/build_script/dn_execute_compose.bash
+++ b/dockerized-norlab-scripts/build_script/dn_execute_compose.bash
@@ -22,6 +22,17 @@
 MSG_ERROR_FORMAT="\033[1;31m"
 MSG_END_FORMAT="\033[0m"
 
+# Variable set for export
+declare -x BUILDKIT_PROGRESS
+declare -x REPOSITORY_VERSION
+#declare -x BASE_IMAGE
+#declare -x OS_NAME
+#declare -x TAG_PACKAGE
+declare -x DEPENDENCIES_BASE_IMAGE
+declare -x TAG_VERSION
+declare -x DEPENDENCIES_BASE_IMAGE_TAG
+declare -x DN_IMAGE_TAG
+declare -x PROJECT_TAG
 
 function dn::execute_compose() {
   # ....Positional argument........................................................................
@@ -36,11 +47,6 @@ function dn::execute_compose() {
   unset DOCKER_EXIT_CODE
   local MAIN_DOCKER_EXIT_CODE=1
 
-  decare -x REPOSITORY_VERSION
-  decare -x BASE_IMAGE
-  decare -x OS_NAME
-  decare -x TAG_PACKAGE
-  decare -x TAG_VERSION
 
   # ....Pre-condition..............................................................................
 

--- a/dockerized-norlab-scripts/build_script/dn_execute_compose_over_build_matrix.bash
+++ b/dockerized-norlab-scripts/build_script/dn_execute_compose_over_build_matrix.bash
@@ -108,7 +108,7 @@ if [[ -n ${NBS_OVERRIDE_BUILD_MATRIX_MAIN} ]]; then
   source "${NBS_OVERRIDE_BUILD_MATRIX_MAIN}"
 fi
 
-n2st::print_msg "Loading build matrix${MSG_DIMMED_FORMAT}${_DOTENV_BUILD_MATRIX}${MSG_END_FORMAT}"
+n2st::print_msg "Loading build matrix ${MSG_DIMMED_FORMAT}${_DOTENV_BUILD_MATRIX}${MSG_END_FORMAT}"
 source "${_DOTENV_BUILD_MATRIX}" || exit 1
 
 set +o allexport

--- a/tests/tests_bats/test_dn_build_all.bats
+++ b/tests/tests_bats/test_dn_build_all.bats
@@ -54,6 +54,7 @@ setup() {
 #  cd "$TESTED_FILE_PATH" || exit
 
   export NBS_OVERRIDE_BUILD_MATRIX_MAIN=build_matrix_config/test/.env.build_matrix.main.mock
+  export BUILD_MATRIX_CONFIG_FILE=build_matrix_config/test/.env.build_matrix.mock
 
 }
 
@@ -104,8 +105,10 @@ teardown() {
 
   run source "./${TESTED_FILE_PATH}/$TESTED_FILE" "--fail-fast" -- "build --dry-run"
   assert_success
-  assert_output --regexp "\[DN-build-system\]".*"Loading main build matrix".*".env.build_matrix.main"
-  assert_output --regexp "\[DN-build-system\]".*"Loading main build matrix override".*"${NBS_OVERRIDE_BUILD_MATRIX_MAIN}"
+
+  # Build matrix source ordering
+  assert_output --regexp "\[DN-build-system\]".*"Loading main build matrix".*".env.build_matrix.main".*"\[DN-build-system\]".*"Loading main build matrix override".*"${NBS_OVERRIDE_BUILD_MATRIX_MAIN}".*"\[DN-build-system\]".*"Loading build matrix".*"${BUILD_MATRIX_CONFIG_FILE}"
+
 
   assert_output --regexp "\[DN-build-system\]".*"Environment variables set for compose:".*"REPOSITORY_VERSION=".*"v0.3.0 hot".*"NBS_MATRIX_SUPPORTED_OS=".*"l4t".*"NBS_MATRIX_L4T_SUPPORTED_VERSIONS=".*"r11.1.1 r22.2.2".*"NBS_MATRIX_L4T_BASE_IMAGES_AND_PKG=".*"dustynv/ros:humble-ros-core-l4t dustynv/ros:humble-pytorch-l4t".*
 

--- a/tests/tests_bats/test_dn_execute_compose.bats
+++ b/tests/tests_bats/test_dn_execute_compose.bats
@@ -75,6 +75,8 @@ setup() {
 
 
 @test "sourcing $TESTED_FILE from bad cwd › expect fail" {
+#  skip "tmp dev" # ToDo: on task end >> delete this line ←
+
   cd "${BATS_DOCKER_WORKDIR}/dockerized-norlab-scripts/"
 
   source ./build_script/$TESTED_FILE
@@ -90,6 +92,7 @@ setup() {
 }
 
 @test "sourcing $TESTED_FILE from ok cwd › expect pass" {
+#  skip "tmp dev" # ToDo: on task end >> delete this line ←
 
   source ./${TESTED_FILE_PATH}/$TESTED_FILE
   run dn::execute_compose ${TEST_DOCKER_COMPOSE_FILE} \
@@ -105,6 +108,7 @@ setup() {
 }
 
 @test "missing docker-compose.yaml file mandatory argument › expect fail" {
+#  skip "tmp dev" # ToDo: on task end >> delete this line ←
 
   source ./${TESTED_FILE_PATH}/$TESTED_FILE
   run dn::execute_compose
@@ -177,6 +181,59 @@ setup() {
 
   set -e
   assert_equal "$DOCKER_EXIT_CODE" 1
+}
+
+@test "Variable are exported to calling script › expect pass" {
+##  skip "tmp dev" # ToDo: on task end >> delete this line ←
+
+  assert_empty "$BUILDKIT_PROGRESS"
+  assert_empty "$REPOSITORY_VERSION"
+  assert_empty "$BASE_IMAGE"
+  assert_empty "$OS_NAME"
+  assert_empty "$TAG_PACKAGE"
+  assert_empty "$TAG_VERSION"
+  assert_empty "$DEPENDENCIES_BASE_IMAGE"
+  assert_empty "$DEPENDENCIES_BASE_IMAGE_TAG"
+  assert_empty "$DN_IMAGE_TAG"
+  assert_empty "$PROJECT_TAG"
+
+  local DOCKER_CMD="version"
+  mock_docker_command_exit_ok
+  set +e
+  source ./${TESTED_FILE_PATH}/$TESTED_FILE
+  dn::execute_compose ${TEST_DOCKER_COMPOSE_FILE} \
+                    --dockerized-norlab-version hot \
+                    --base-image dustynv/pytorch \
+                    --os-name arbitratyName \
+                    --tag-package 2.1 \
+                    --tag-version r35.0.0 \
+                    --docker-debug-logs \
+                    --ci-test-force-runing-docker-cmd -- "$DOCKER_CMD"
+
+  DOCKER_EXIT_CODE=$?
+  set -e
+
+  assert_not_empty "$BUILDKIT_PROGRESS"
+  assert_not_empty "$REPOSITORY_VERSION"
+  assert_not_empty "$BASE_IMAGE"
+  assert_not_empty "$OS_NAME"
+  assert_not_empty "$TAG_PACKAGE"
+  assert_not_empty "$TAG_VERSION"
+  assert_not_empty "$DEPENDENCIES_BASE_IMAGE"
+  assert_not_empty "$DEPENDENCIES_BASE_IMAGE_TAG"
+  assert_not_empty "$DN_IMAGE_TAG"
+  assert_not_empty "$PROJECT_TAG"
+
+  assert_equal "$BUILDKIT_PROGRESS" "plain"
+  assert_equal "$REPOSITORY_VERSION" "hot"
+  assert_equal "$BASE_IMAGE" "dustynv/pytorch"
+  assert_equal "$OS_NAME" "arbitratyName"
+  assert_equal "$TAG_PACKAGE" "2.1"
+  assert_equal "$TAG_VERSION" "r35.0.0"
+  assert_equal "$DEPENDENCIES_BASE_IMAGE" "dustynv/pytorch"
+  assert_equal "$DEPENDENCIES_BASE_IMAGE_TAG" "2.1-r35.0.0"
+  assert_equal "$DN_IMAGE_TAG" "DN-hot-2.1-r35.0.0"
+  assert_equal "$PROJECT_TAG" "arbitratyName-r35.0.0"
 }
 
 @test "flags that set env variable" {

--- a/tests/tests_bats/test_dn_execute_compose_over_build_matrix.bats
+++ b/tests/tests_bats/test_dn_execute_compose_over_build_matrix.bats
@@ -154,9 +154,7 @@ setup() {
                                               -- "$DOCKER_CMD"
   set -e
   assert_success
-  assert_output --regexp "\[DN-build-system\]".*"Loading main build matrix".*".env.build_matrix.main"
-  assert_output --regexp "\[DN-build-system\]".*"Loading main build matrix override".*"${NBS_OVERRIDE_BUILD_MATRIX_MAIN}"
-  assert_output --regexp "\[DN-build-system\]".*"Loading build matrix".*"${BUILD_MATRIX_CONFIG_FILE}"
+  assert_output --regexp "\[DN-build-system\]".*"Loading main build matrix".*".env.build_matrix.main".*"\[DN-build-system\]".*"Loading main build matrix override".*"${NBS_OVERRIDE_BUILD_MATRIX_MAIN}".*"\[DN-build-system\]".*"Loading build matrix".*"${BUILD_MATRIX_CONFIG_FILE}"
 
 #  bats_print_run_env_variable
 }


### PR DESCRIPTION
# Description
### Summary:

Fix error related to executing docker compose config with env var declared in the compose file with variable substitution check but for which some of those where not exported outside the function dn::execute_compose

---

# Checklist:

### Code related
- [x] I have made corresponding changes to the documentation (i.e.: function/class, script header, README.md)
- [x] I have commented hard-to-understand code 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes 
- [x] My commit messages follow the [conventional commits](https://www.conventionalcommits.org) specification. See `commit_msg_reference.md` in the repository root for details

### PR creation related 
- [x] My pull request `base ref` branch is set to the `dev` branch (the _build-system_ won't be triggered otherwise) 
- [x] My pull request branch is up-to-date with the `dev` branch (the _build-system_ will reject it otherwise)

### PR description related 
- [x] I have included a quick summary of the changes
- [x] I have indicated the related issue's id with `# <issue-id>` if changes are of type `fix`

 ## Note for repository admins
 ### Release PR related
- Only repository admins have the privilege to `push/merge` on the default branch (ie: `main`) and the `release` branch.
- Keep PR in `draft` mode until all the release reviewers are ready to push the release. 
- Once a PR from `release` -> `main` branch is created (not in draft mode), it triggers the _build-system_ test
- On merge to the `main` branch, it triggers the _semantic-release automation_
