### PR TITLE
Fix ROS core build step failure

### DIFF
--- a/build_matrix_config/dev/.env.build_matrix.dev
+++ b/build_matrix_config/dev/.env.build_matrix.dev
@@ -11,8 +11,8 @@
 #NBS_MATRIX_ROS_DISTRO=('none')
 #NBS_MATRIX_ROS_PKG=('none')
 
-#NBS_COMPOSE_DIR=dockerized-norlab-images/core-images/base-images/ros2-install
-##NBS_EXECUTE_BUILD_MATRIX_OVER_COMPOSE_FILE=${NBS_COMPOSE_DIR}/docker-compose.ros2.build.yaml
+NBS_COMPOSE_DIR=dockerized-norlab-images/core-images/base-images/ros2-install
+NBS_EXECUTE_BUILD_MATRIX_OVER_COMPOSE_FILE=${NBS_COMPOSE_DIR}/docker-compose.ros2.build.yaml
 #NBS_EXECUTE_BUILD_MATRIX_OVER_COMPOSE_FILE=${NBS_COMPOSE_DIR}/docker-compose.ros2-vaul.build.yaml
 
 #NBS_COMPOSE_DIR=dockerized-norlab-images/core-images/dependencies
@@ -26,8 +26,8 @@
 #NBS_COMPOSE_DIR=dockerized-norlab-images/core-images/pkg-perception
 #NBS_EXECUTE_BUILD_MATRIX_OVER_COMPOSE_FILE=${NBS_COMPOSE_DIR}/docker-compose.dn-perception.build.yaml
 
-NBS_COMPOSE_DIR=dockerized-norlab-images/core-images/dn-project
-NBS_EXECUTE_BUILD_MATRIX_OVER_COMPOSE_FILE=${NBS_COMPOSE_DIR}/docker-compose.dn-project.build.yaml
+#NBS_COMPOSE_DIR=dockerized-norlab-images/core-images/dn-project
+#NBS_EXECUTE_BUILD_MATRIX_OVER_COMPOSE_FILE=${NBS_COMPOSE_DIR}/docker-compose.dn-project.build.yaml
 
 #
 # Build Dockerized-NorLab for the following base images

--- a/build_matrix_config/dev/.env.build_matrix.main.dev
+++ b/build_matrix_config/dev/.env.build_matrix.main.dev
@@ -59,7 +59,8 @@ NBS_MATRIX_ROS_DISTRO=('foxy')
 
 NBS_MATRIX_ROS_PKG=()
 NBS_MATRIX_ROS_PKG+=('ros-core')
-#NBS_MATRIX_ROS_PKG+=('ros-base')
+NBS_MATRIX_ROS_PKG+=('ros-base')
+#NBS_MATRIX_ROS_PKG+=('desktop')
 #NBS_MATRIX_ROS_PKG+=('ros1-bridge')
 
 #

--- a/dockerized-norlab-images/container-tools/dn_info.bash
+++ b/dockerized-norlab-images/container-tools/dn_info.bash
@@ -65,6 +65,8 @@ function dn::show_container_runtime_information() {
   n2st::set_which_python3_version
   DN_PYTHON3_VERSION=${PYTHON3_VERSION?err}
 
+  # (Priority) ToDo: replace `DN_IMAGE_ARCHITECTURE` by `DN_HOST` wich is declare in DN-project
+  #    and set in docker compose files
   n2st::set_which_architecture_and_os
   DN_IMAGE_ARCHITECTURE=${IMAGE_ARCH_AND_OS:?err}
 

--- a/dockerized-norlab-images/core-images/base-images/ros2-install/Dockerfile.ros2
+++ b/dockerized-norlab-images/core-images/base-images/ros2-install/Dockerfile.ros2
@@ -207,9 +207,9 @@ RUN echo "sourcing /opt/ros/${ROS_DISTRO}/setup.bash" \
     && source /opt/ros/${ROS_DISTRO}/setup.bash \
     && apt-get update --fix-missing \
     && rosdep init \
-    && rosdep update
-
-    #    && rosdep fix-permissions
+    && rosdep update --rosdistro "${ROS_DISTRO}" \
+    && rosdep fix-permissions \
+    || exit 1
 
 RUN colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml  \
     && colcon mixin update  \
@@ -226,7 +226,8 @@ RUN echo "sourcing /opt/ros/${ROS_DISTRO}/setup.bash" \
             --from-path ./src  \
             --rosdistro ${ROS_DISTRO}  \
             -y \
-    && colcon version-check
+    && colcon version-check \
+    || exit 1
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
@@ -247,7 +248,8 @@ RUN COLCON_FLAGS=() \
     && echo -e "COLCON_FLAGS=("${COLCON_FLAGS[*]}")" \
     && echo "sourcing /opt/ros/${ROS_DISTRO}/setup.bash" \
     && source /opt/ros/${ROS_DISTRO}/setup.bash \
-    && colcon build ${COLCON_FLAGS[@]}
+    && colcon build ${COLCON_FLAGS[@]} \
+    || exit 1
 
 # ===Remove dustynv entrypoint from .bashrc. ======================================================
 # Note: Source ROS in the dn_entrypoint.init.bash instead"
@@ -276,7 +278,8 @@ RUN echo "sourcing /opt/ros/${ROS_DISTRO}/setup.bash" \
     && echo COLCON_PREFIX_PATH=${COLCON_PREFIX_PATH:?'Build argument needs to be set and non-empty.'} \
     && python -c "import rclpy" \
     && ros2 pkg list \
-    && colcon --log-level error test-result --all --verbose
+    && colcon --log-level error test-result --all --verbose \
+    || exit 1
 
 RUN if [[ ${ROS_PKG} =~ "desktop".* ]] && [[ -n $(pip list | grep cv2) ]]; then \
       python3 -c "import cv2; print( f'Opencv version: {cv2.__version__}' )" ; \

--- a/dockerized-norlab-images/core-images/dependencies/Dockerfile.ros2-dn-custom
+++ b/dockerized-norlab-images/core-images/dependencies/Dockerfile.ros2-dn-custom
@@ -80,7 +80,7 @@ RUN <<EOF
 #    source ${DN_DEV_WORKSPACE}/install/setup.bash
 
     apt-get update --fix-missing
-    rosdep update --rosdistro ${ROS_DISTRO} --include-eol-distros
+    rosdep update --rosdistro ${ROS_DISTRO}
     rosdep fix-permissions
     rosdep install \
         --ignore-packages-from-source \

--- a/dockerized-norlab-images/core-images/dn-project/project-deploy/Dockerfile
+++ b/dockerized-norlab-images/core-images/dn-project/project-deploy/Dockerfile
@@ -96,7 +96,7 @@ EOF
 # ....Project spoecific ROS setup..................................................................
 WORKDIR ${DN_DEV_WORKSPACE}
 RUN <<EOF
-    rosdep update --rosdistro ${ROS_DISTRO} --include-eol-distros
+    rosdep update --rosdistro ${ROS_DISTRO}
     rosdep fix-permissions
     rosdep install \
         --ignore-packages-from-source \

--- a/dockerized-norlab-images/core-images/pkg-perception/dn-perception-norlab-stack/Dockerfile
+++ b/dockerized-norlab-images/core-images/pkg-perception/dn-perception-norlab-stack/Dockerfile
@@ -68,7 +68,7 @@ RUN echo "sourcing /opt/ros/${ROS_DISTRO}/setup.bash" \
     && echo "sourcing ${DN_DEV_WORKSPACE}/install/setup.bash" \
     && source ${DN_DEV_WORKSPACE}/install/setup.bash \
     && apt-get update --fix-missing \
-    && rosdep update --rosdistro ${ROS_DISTRO} --include-eol-distros \
+    && rosdep update --rosdistro ${ROS_DISTRO} \
     && rosdep fix-permissions \
     && rosdep install  \
             --ignore-packages-from-source \


### PR DESCRIPTION
# Description
### Summary:

This pull request resolves the ROS core build failure by:
- Updating the `rosdep update` instruction to include the specific distro flag.
- Removing the inclusion of end-of-life (EOL) distro flags across the build setup.

Issue: NMO-655

---

# Checklist:

### Code related
- [ ] I have made corresponding changes to the documentation (i.e.: function/class, script header, README.md)
- [ ] I have commented hard-to-understand code 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes 
- [x] My commit messages follow the [conventional commits](https://www.conventionalcommits.org) specification. See `commit_msg_reference.md` in the repository root for details

### PR creation related 
- [x] My pull request `base ref` branch is set to the `dev` branch (the _build-system_ won't be triggered otherwise) 
- [ x My pull request branch is up-to-date with the `dev` branch (the _build-system_ will reject it otherwise)

### PR description related 
- [x] I have included a quick summary of the changes
- [x] I have indicated the related issue's id with `# <issue-id>` if changes are of type `fix`

 ## Note for repository admins
 ### Release PR related
- Only repository admins have the privilege to `push/merge` on the default branch (ie: `main`) and the `release` branch.
- Keep PR in `draft` mode until all the release reviewers are ready to push the release. 
- Once a PR from `release` -> `main` branch is created (not in draft mode), it triggers the _build-system_ test
- On merge to the `main` branch, it triggers the _semantic-release automation_