### PR TITLE
Project-deploy related improvement

### DIFF
--- a/dockerized-norlab-images/container-tools/dn_info.bash
+++ b/dockerized-norlab-images/container-tools/dn_info.bash
@@ -65,8 +65,7 @@ function dn::show_container_runtime_information() {
   n2st::set_which_python3_version
   DN_PYTHON3_VERSION=${PYTHON3_VERSION?err}
 
-  # (Priority) ToDo: replace `DN_IMAGE_ARCHITECTURE` by `DN_HOST` wich is declare in DN-project
-  #    and set in docker compose files
+  # ToDo: NMO-669 refactor: replace DN_IMAGE_ARCHITECTURE by DN_HOST which is declare in DN-project
   n2st::set_which_architecture_and_os
   DN_IMAGE_ARCHITECTURE=${IMAGE_ARCH_AND_OS:?err}
 

--- a/dockerized-norlab-images/core-images/dn-project/dn_callback_execute_compose_post.bash
+++ b/dockerized-norlab-images/core-images/dn-project/dn_callback_execute_compose_post.bash
@@ -3,8 +3,15 @@
 # ===============================================================================================
 # Post docker command execution callback
 #
+# Notes:
+#   - It is source and executed by dn_execute_compose.bash
+#   - Its required to be at the same level as its corresponding docker-compose.*.yaml
+#
 # Usage:
 #   $ source dn_callback_execute_compose_post.bash && dn::callback_execute_compose_post
+#
+# Notes:
+#   See utilities/tmp/README.md for details on role of `dockerized-norlab-project-mock`
 #
 # Globals:
 #   Read DN_PATH

--- a/dockerized-norlab-images/core-images/dn-project/dn_callback_execute_compose_pre.bash
+++ b/dockerized-norlab-images/core-images/dn-project/dn_callback_execute_compose_pre.bash
@@ -6,6 +6,9 @@
 # Usage:
 #   $ source dn_callback_execute_compose_pre.bash && callback_execute_compose_pre
 #
+# Notes:
+#   See utilities/tmp/README.md for details on role of `dockerized-norlab-project-mock`
+#
 # Globals:
 #   Read DN_PATH
 #

--- a/dockerized-norlab-images/core-images/dn-project/docker-compose.dn-project.build.yaml
+++ b/dockerized-norlab-images/core-images/dn-project/docker-compose.dn-project.build.yaml
@@ -90,6 +90,7 @@ services:
         BASE_IMAGE_TAG: ${PROJECT_TAG:?err}
         DN_PROJECT_DEPLOY_REPO_BRANCH: ${DN_PROJECT_DEPLOY_REPO_BRANCH:?err}  # Option: main, dev or tag version (ie v*.*.*)
         BUILDKIT_CONTEXT_KEEP_GIT_DIR: 1
+        DN_DEV_TESTS: true
     depends_on:
       - project-core
 

--- a/dockerized-norlab-images/core-images/dn-project/project-deploy/Dockerfile
+++ b/dockerized-norlab-images/core-images/dn-project/project-deploy/Dockerfile
@@ -13,6 +13,8 @@ ENV DN_PROJECT_DEPLOY_REPO_BRANCH=${DN_PROJECT_DEPLOY_REPO_BRANCH:?'Build argume
 ENV DN_PROJECT_SERVICE=project-deploy
 ENV DN_PROJECT_SERVICE_DIR=/dockerized-norlab/project/${DN_PROJECT_SERVICE}
 
+ARG DN_DEV_TESTS=${DN_DEV_TESTS:-false}
+
 RUN <<EOF
     n2st::print_msg "Pre-condition checks"
     {
@@ -47,15 +49,20 @@ WORKDIR ${DN_PROJECT_PATH}
 # - DN_DEV_WORKSPACE: /ros2_ws/src
 # - DN_PROJECT_PATH: /ros2_ws/src/dockerized-norlab-project-mock
 RUN <<EOF
-    if [[ "${DN_PROJECT_GIT_NAME}" == "dockerized-norlab-project-mock" ]]; then
+    if [[ "${DN_DEV_TESTS}" == "true" ]]; then
         # Development test to validate that the git checkout operation was succesfull (pre)
+        # mock_file.txt only exist on the dev branch
+        tree -L 2 -a "${DN_PROJECT_PATH}"
         {
+            test "${DN_PROJECT_GIT_NAME}" == "dockerized-norlab-project-mock" && \
             test "${DN_PROJECT_DEPLOY_REPO_BRANCH}" == "dev" && \
             test "$(git branch --show-current)" == "main" && \
             test ! -f "src/mock_file.txt" ;
         } || exit 1
     fi
+EOF
 
+RUN <<EOF
     # ....Debug information (pre-checkout)....................................................
     n2st::print_msg "Debug information (pre-checkout)"
     tree -L 2 -aug "${DN_DEV_WORKSPACE}/src"
@@ -81,8 +88,10 @@ RUN <<EOF
     # ....Debug information (post-checkout)....................................................
     n2st::print_msg "Debug information (post-checkout)"
     tree -L 2 -aug "${DN_DEV_WORKSPACE}/src"
+EOF
 
-    if [[ "${DN_PROJECT_GIT_NAME}" == "dockerized-norlab-project-mock" ]]; then
+RUN <<EOF
+    if [[ "${DN_DEV_TESTS}" == "true" ]]; then
         # Development test to validate that the git checkout operation was succesfull (post)
         {
             test "$(git branch --show-current)" == "dev" && \
@@ -93,7 +102,7 @@ RUN <<EOF
 EOF
 
 
-# ....Project spoecific ROS setup..................................................................
+# ....Project specific ROS setup..................................................................
 WORKDIR ${DN_DEV_WORKSPACE}
 RUN <<EOF
     rosdep update --rosdistro ${ROS_DISTRO}
@@ -111,11 +120,6 @@ WORKDIR ${DN_DEV_WORKSPACE}
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN <<EOF
-#    echo "sourcing ${DN_DEV_WORKSPACE}/install/setup.bash"
-#    source ${DN_DEV_WORKSPACE}/install/setup.bash
-#    echo "sourcing /opt/ros/${ROS_DISTRO}/setup.bash"
-#    source /opt/ros/${ROS_DISTRO}/setup.bash
-
     COLCON_FLAGS=()
     if [[ ${TARGETPLATFORM:?err} != ${BUILDPLATFORM:?err} ]]; then
       n2st::print_msg "Builder is running in architecture virtualisation"
@@ -134,18 +138,19 @@ RUN <<EOF
     colcon build ${COLCON_FLAGS[@]}
 EOF
 
-# ....DN and DN-project entrypoints and utilities................................................
-
-# Note: Its easier and more robust to copy DN files to root and then symlink them in project user.
-WORKDIR ${DN_PROJECT_SERVICE_DIR}
-COPY dn_entrypoint.init.bash dn_entrypoint.attach.bash ./
-
 # ToDo: refactor project-develop/Dockerfile the project-specific-ros-setup stage as a standalone
 #script that can be executed by project-deploy (ref task NMO-558)
 
 # ToDo: Move project-develop/dn_ros2_rebuild_dev_workspace.bash and
 # project-develop/dn_fetch_ros_env_variables.bash to a dn-project wide dir so that its available on
 # all dn-project service (ref task NMO-558)
+
+# ....DN and DN-project entrypoints and utilities................................................
+
+# Note: Its easier and more robust to copy DN files to root and then symlink them in project user.
+WORKDIR ${DN_PROJECT_SERVICE_DIR}
+COPY dn_entrypoint.init.bash dn_entrypoint.attach.bash ./
+
 
 RUN chmod +x dn_entrypoint.init.bash && \
     chmod +x dn_entrypoint.attach.bash

--- a/dockerized-norlab-images/core-images/dn-project/project-deploy/Dockerfile
+++ b/dockerized-norlab-images/core-images/dn-project/project-deploy/Dockerfile
@@ -41,8 +41,9 @@ ENV PYTHONUNBUFFERED=0
 # whether it's a personal computer, a robot or a CI server its safer and easier to manage to
 # delegate the responsibility of secret management to the user.
 WORKDIR "${DN_DEV_WORKSPACE}/src"
+COPY --from=context-dn-project-local-src-path . ${DN_PROJECT_GIT_NAME}
 #COPY --chown=${DN_PROJECT_USER} --from=context-dn-project-local-src-path . ${DN_PROJECT_GIT_NAME}
-COPY --chown="$(id -u ${DN_PROJECT_USER}):$(id -g ${DN_PROJECT_USER})" --from=context-dn-project-local-src-path . ${DN_PROJECT_GIT_NAME}
+#COPY --chown="$(id -u ${DN_PROJECT_USER}):$(id -g ${DN_PROJECT_USER})" --from=context-dn-project-local-src-path . ${DN_PROJECT_GIT_NAME}
 
 WORKDIR ${DN_PROJECT_PATH}
 
@@ -52,14 +53,14 @@ WORKDIR ${DN_PROJECT_PATH}
 RUN <<EOF
     # ....Debug information (pre-checkout).........................................................
     n2st::print_msg "Debug information (pre-checkout)"
-    tree -L 2 -aug "${DN_DEV_WORKSPACE}/src"
+    tree -L 2 -a "${DN_DEV_WORKSPACE}/src"
     echo
-    tree -L 3 -aug "${DN_PROJECT_PATH}"
+    tree -L 3 -a "${DN_PROJECT_PATH}"
     echo
     echo -e "\ncat ${DN_PROJECT_PATH}/.git"
     cat ${DN_PROJECT_PATH}/.git
     echo
-    tree -L 2 -aug ${DN_PROJECT_PATH}/.git
+    tree -L 2 -a ${DN_PROJECT_PATH}/.git
 
     # (CRITICAL) ToDo: assessment
 #    git init ${DN_PROJECT_PATH}

--- a/dockerized-norlab-images/core-images/dn-project/project-deploy/Dockerfile
+++ b/dockerized-norlab-images/core-images/dn-project/project-deploy/Dockerfile
@@ -43,7 +43,6 @@ ENV PYTHONUNBUFFERED=0
 WORKDIR "${DN_DEV_WORKSPACE}/src"
 COPY --from=context-dn-project-local-src-path . ${DN_PROJECT_GIT_NAME}
 #COPY --chown=${DN_PROJECT_USER} --from=context-dn-project-local-src-path . ${DN_PROJECT_GIT_NAME}
-#COPY --chown="$(id -u ${DN_PROJECT_USER}):$(id -g ${DN_PROJECT_USER})" --from=context-dn-project-local-src-path . ${DN_PROJECT_GIT_NAME}
 
 WORKDIR ${DN_PROJECT_PATH}
 
@@ -61,10 +60,6 @@ RUN <<EOF
     cat ${DN_PROJECT_PATH}/.git
     echo
     tree -L 2 -a ${DN_PROJECT_PATH}/.git
-
-    # (CRITICAL) ToDo: assessment
-#    git init ${DN_PROJECT_PATH}
-#    git submodule init && git submodule update
 
     if [[ "${DN_DEV_TESTS}" == "true" ]]; then
         n2st::print_msg "Development test to validate that the setup for testing git checkout operation is ok (pre)."

--- a/dockerized-norlab-images/core-images/dn-project/project-deploy/Dockerfile
+++ b/dockerized-norlab-images/core-images/dn-project/project-deploy/Dockerfile
@@ -54,9 +54,17 @@ WORKDIR ${DN_PROJECT_PATH}
 # - DN_DEV_WORKSPACE: /ros2_ws/src
 # - DN_PROJECT_PATH: /ros2_ws/src/dockerized-norlab-project-mock
 RUN <<EOF
+    # ....Debug information (pre-checkout).........................................................
+    n2st::print_msg "Debug information (pre-checkout)"
+    tree -L 2 -aug "${DN_DEV_WORKSPACE}/src"
+    echo -e "\ncat ${DN_PROJECT_PATH}/.git"
+    cat ${DN_PROJECT_PATH}/.git
+    echo
+    tree -L 2 -aug ${DN_PROJECT_PATH}/.git
+
     # (CRITICAL) ToDo: assessment
-    git init ${DN_PROJECT_PATH}
-    git submodule init && git submodule update
+#    git init ${DN_PROJECT_PATH}
+#    git submodule init && git submodule update
 
     if [[ "${DN_DEV_TESTS}" == "true" ]]; then
         n2st::print_msg "Development test to validate that the setup for testing git checkout operation is ok (pre)."
@@ -73,13 +81,6 @@ RUN <<EOF
         test "$( basename $( git rev-parse --show-toplevel ) )" == "${DN_PROJECT_GIT_NAME}" || n2st::print_msg_error_and_exit "'git rev-parse --show-toplevel' should point to  ${DN_PROJECT_GIT_NAME} but it point to '$( git rev-parse --show-toplevel )'"
     fi
 
-    # ....Debug information (pre-checkout).........................................................
-    n2st::print_msg "Debug information (pre-checkout)"
-    tree -L 2 -aug "${DN_DEV_WORKSPACE}/src"
-    echo -e "\ncat ${DN_PROJECT_PATH}/.git"
-    cat ${DN_PROJECT_PATH}/.git
-    echo
-    tree -L 2 -aug ${DN_PROJECT_PATH}/.git
 EOF
 
 RUN <<EOF

--- a/dockerized-norlab-images/core-images/dn-project/project-deploy/Dockerfile
+++ b/dockerized-norlab-images/core-images/dn-project/project-deploy/Dockerfile
@@ -50,13 +50,14 @@ COPY --chown="$(id -u ${DN_PROJECT_USER}):$(id -g ${DN_PROJECT_USER})" --from=co
 
 WORKDIR ${DN_PROJECT_PATH}
 
-# (CRITICAL) ToDo: assessment
-RUN git submodule init && git submodule update
-
 # Dev note:
 # - DN_DEV_WORKSPACE: /ros2_ws/src
 # - DN_PROJECT_PATH: /ros2_ws/src/dockerized-norlab-project-mock
 RUN <<EOF
+    # (CRITICAL) ToDo: assessment
+    git init ${DN_PROJECT_PATH}
+    git submodule init && git submodule update
+
     if [[ "${DN_DEV_TESTS}" == "true" ]]; then
         n2st::print_msg "Development test to validate that the setup for testing git checkout operation is ok (pre)."
         test "${DN_PROJECT_GIT_NAME}" == "dockerized-norlab-project-mock" || n2st::print_msg_error_and_exit "${DN_PROJECT_GIT_NAME} != dockerized-norlab-project-mock"

--- a/dockerized-norlab-images/core-images/dn-project/project-deploy/Dockerfile
+++ b/dockerized-norlab-images/core-images/dn-project/project-deploy/Dockerfile
@@ -47,35 +47,42 @@ ENV PYTHONUNBUFFERED=0
 WORKDIR "${DN_DEV_WORKSPACE}/src"
 #COPY --chown=${DN_PROJECT_USER} --from=context-dn-project-local-src-path . ${DN_PROJECT_GIT_NAME}
 COPY --chown="$(id -u ${DN_PROJECT_USER}):$(id -g ${DN_PROJECT_USER})" --from=context-dn-project-local-src-path . ${DN_PROJECT_GIT_NAME}
+
 WORKDIR ${DN_PROJECT_PATH}
+
+# (CRITICAL) ToDo: assessment
+RUN git submodule init && git submodule update
+
 # Dev note:
 # - DN_DEV_WORKSPACE: /ros2_ws/src
 # - DN_PROJECT_PATH: /ros2_ws/src/dockerized-norlab-project-mock
 RUN <<EOF
     if [[ "${DN_DEV_TESTS}" == "true" ]]; then
-        n2st::print_msg "Development test to validate that the git checkout operation was succesfull (pre)."
+        n2st::print_msg "Development test to validate that the setup for testing git checkout operation is ok (pre)."
         test "${DN_PROJECT_GIT_NAME}" == "dockerized-norlab-project-mock" || n2st::print_msg_error_and_exit "${DN_PROJECT_GIT_NAME} != dockerized-norlab-project-mock"
         test "${DN_PROJECT_DEPLOY_REPO_BRANCH}" == "dev" || n2st::print_msg_error_and_exit "${DN_PROJECT_DEPLOY_REPO_BRANCH} != dev"
-        test "$( basename $( git remote get-url origin ) .git )" == "dockerized-norlab-project-mock" || n2st::print_msg_error_and_exit "'git remote get-url origin' should point to  dockerized-norlab-project-mock but it point to '$( git remote get-url origin )'"
-        test "$( basename $( git rev-parse --show-toplevel ) )" == "dockerized-norlab-project-mock" || n2st::print_msg_error_and_exit "'git rev-parse --show-toplevel' should point to  dockerized-norlab-project-mock but it point to '$( git rev-parse --show-toplevel )'"
         test "$(git branch --show-current)" == "main" || n2st::print_msg_error_and_exit "$(git branch --show-current) != main"
         test ! -f "src/mock_file.txt" || n2st::print_msg_error_and_exit "mock_file.txt should only exist on the dev branch"
         echo
         tree -L 2 -a -hug "${DN_PROJECT_PATH}"
         echo
+    else
+        # ....Sanity check (pre)...................................................................
+        test "$( basename $( git remote get-url origin ) .git )" == "${DN_PROJECT_GIT_NAME}" || n2st::print_msg_error_and_exit "'git remote get-url origin' should point to  ${DN_PROJECT_GIT_NAME} but it point to '$( git remote get-url origin )'"
+        test "$( basename $( git rev-parse --show-toplevel ) )" == "${DN_PROJECT_GIT_NAME}" || n2st::print_msg_error_and_exit "'git rev-parse --show-toplevel' should point to  ${DN_PROJECT_GIT_NAME} but it point to '$( git rev-parse --show-toplevel )'"
     fi
-EOF
 
-RUN <<EOF
-    # ....Debug information (pre-checkout)....................................................
+    # ....Debug information (pre-checkout).........................................................
     n2st::print_msg "Debug information (pre-checkout)"
     tree -L 2 -aug "${DN_DEV_WORKSPACE}/src"
     echo -e "\ncat ${DN_PROJECT_PATH}/.git"
     cat ${DN_PROJECT_PATH}/.git
     echo
     tree -L 2 -aug ${DN_PROJECT_PATH}/.git
+EOF
 
-    # ....Checkout...........................................................................
+RUN <<EOF
+    # ....Checkout.................................................................................
     n2st::print_msg "git status"
     git status || exit 1
 
@@ -91,19 +98,24 @@ RUN <<EOF
     n2st::print_msg_warning "Note on git checkout faillure: If you experience problem checking out a tag, use prefix 'tags/<my-tags-name>'
     e.g.: DN_PROJECT_DEPLOY_REPO_BRANCH=\"tags/v0.0.1\" in your .dockerized_norlab_project/configuration/.env file"
 
-    # ....Debug information (post-checkout)....................................................
-    n2st::print_msg "Debug information (post-checkout)"
-    tree -L 2 -aug "${DN_DEV_WORKSPACE}/src"
 EOF
 
 RUN <<EOF
+
+    # ....Debug information (post-checkout)........................................................
+    n2st::print_msg "Debug information (post-checkout)"
+    tree -L 2 -aug "${DN_DEV_WORKSPACE}/src"
+
     if [[ "${DN_DEV_TESTS}" == "true" ]]; then
-        n2st::print_msg "Development test to validate that the git checkout operation was succesfull (post)"
+        n2st::print_msg "Development test to validate that the setup for testing git checkout operation is ok (post)."
         test "$(git branch --show-current)" == "dev" || n2st::print_msg_error_and_exit "$(git branch --show-current) != dev"
         test -f "src/mock_file.txt" || n2st::print_msg_error_and_exit "mock_file.txt should exist on the dev branch"
         echo
         tree -L 2 -a -hug "${DN_PROJECT_PATH}"
         echo
+    else
+        # ....Sanity check (post)..................................................................
+        test "$(git branch --show-current)" == "${DN_PROJECT_DEPLOY_REPO_BRANCH}" || n2st::print_msg_error_and_exit "$(git branch --show-current) != "${DN_PROJECT_DEPLOY_REPO_BRANCH}""
     fi
 
 EOF

--- a/dockerized-norlab-images/core-images/dn-project/project-deploy/Dockerfile
+++ b/dockerized-norlab-images/core-images/dn-project/project-deploy/Dockerfile
@@ -51,15 +51,10 @@ WORKDIR ${DN_PROJECT_PATH}
 RUN <<EOF
     if [[ "${DN_DEV_TESTS}" == "true" ]]; then
         n2st::print_msg "Development test to validate that the git checkout operation was succesfull (pre)."
-
-        # (Priority) ToDo: on task end >> delete next bloc ↓↓
-        git status
-        git branch --list --allo
-
         test "${DN_PROJECT_GIT_NAME}" == "dockerized-norlab-project-mock" || n2st::print_msg_error_and_exit "${DN_PROJECT_GIT_NAME} != dockerized-norlab-project-mock"
         test "${DN_PROJECT_DEPLOY_REPO_BRANCH}" == "dev" || n2st::print_msg_error_and_exit "${DN_PROJECT_DEPLOY_REPO_BRANCH} != dev"
-        test "$( basename $( git remote get-url origin ) .git )" == "dockerized-norlab-project-mock" || n2st::print_msg_error_and_exit "'git remote get-url origin' should point to  dockerized-norlab-project-mock but it point to $( git remote get-url origin )"
-        test "$( basename $( git rev-parse --show-toplevel ) )" == "dockerized-norlab-project-mock" || n2st::print_msg_error_and_exit "'git rev-parse --show-toplevel' should point to  dockerized-norlab-project-mock but it point to $( git rev-parse --show-toplevel )"
+        test "$( basename $( git remote get-url origin ) .git )" == "dockerized-norlab-project-mock" || n2st::print_msg_error_and_exit "'git remote get-url origin' should point to  dockerized-norlab-project-mock but it point to '$( git remote get-url origin )'"
+        test "$( basename $( git rev-parse --show-toplevel ) )" == "dockerized-norlab-project-mock" || n2st::print_msg_error_and_exit "'git rev-parse --show-toplevel' should point to  dockerized-norlab-project-mock but it point to '$( git rev-parse --show-toplevel )'"
         test "$(git branch --show-current)" == "main" || n2st::print_msg_error_and_exit "$(git branch --show-current) != main"
         test ! -f "src/mock_file.txt" || n2st::print_msg_error_and_exit "mock_file.txt should only exist on the dev branch"
         echo
@@ -77,16 +72,16 @@ RUN <<EOF
 
     # ....Checkout...........................................................................
     n2st::print_msg "git status"
-    git status
+    git status || exit 1
 
     n2st::print_msg "List repository branches local and remote"
-    git branch --list --all
+    git branch --list --all || exit 1
 
     n2st::print_msg "List repository tags"
-    git tag --list
+    git tag --list || exit 1
 
     n2st::print_msg "Checking out branch ${DN_PROJECT_DEPLOY_REPO_BRANCH}"
-    git checkout "${DN_PROJECT_DEPLOY_REPO_BRANCH}"
+    git checkout "${DN_PROJECT_DEPLOY_REPO_BRANCH}" || exit 1
 
     n2st::print_msg_warning "Note on git checkout faillure: If you experience problem checking out a tag, use prefix 'tags/<my-tags-name>'
     e.g.: DN_PROJECT_DEPLOY_REPO_BRANCH=\"tags/v0.0.1\" in your .dockerized_norlab_project/configuration/.env file"

--- a/dockerized-norlab-images/core-images/dn-project/project-deploy/Dockerfile
+++ b/dockerized-norlab-images/core-images/dn-project/project-deploy/Dockerfile
@@ -3,10 +3,6 @@ ARG BASE_IMAGE
 ARG BASE_IMAGE_TAG
 FROM ${BASE_IMAGE:?err}:${BASE_IMAGE_TAG:?err} AS package-project-src-code
 
-# (CRITICAL) ToDo: on task NMO-584 end >> delete next bloc ↓↓
-#ARG IS_TEAMCITY_RUN
-#ENV IS_TEAMCITY_RUN=${IS_TEAMCITY_RUN:-false}
-
 ARG DN_PROJECT_DEPLOY_REPO_BRANCH
 ENV DN_PROJECT_DEPLOY_REPO_BRANCH=${DN_PROJECT_DEPLOY_REPO_BRANCH:?'Build argument needs to be set and non-empty.'}
 
@@ -57,6 +53,9 @@ RUN <<EOF
     # ....Debug information (pre-checkout).........................................................
     n2st::print_msg "Debug information (pre-checkout)"
     tree -L 2 -aug "${DN_DEV_WORKSPACE}/src"
+    echo
+    tree -L 3 -aug "${DN_PROJECT_PATH}"
+    echo
     echo -e "\ncat ${DN_PROJECT_PATH}/.git"
     cat ${DN_PROJECT_PATH}/.git
     echo
@@ -106,7 +105,7 @@ RUN <<EOF
 
     # ....Debug information (post-checkout)........................................................
     n2st::print_msg "Debug information (post-checkout)"
-    tree -L 2 -aug "${DN_DEV_WORKSPACE}/src"
+    tree -L 2 -aug "${DN_PROJECT_PATH}"
 
     if [[ "${DN_DEV_TESTS}" == "true" ]]; then
         n2st::print_msg "Development test to validate that the setup for testing git checkout operation is ok (post)."

--- a/dockerized-norlab-images/core-images/dn-project/project-deploy/Dockerfile
+++ b/dockerized-norlab-images/core-images/dn-project/project-deploy/Dockerfile
@@ -51,6 +51,11 @@ WORKDIR ${DN_PROJECT_PATH}
 RUN <<EOF
     if [[ "${DN_DEV_TESTS}" == "true" ]]; then
         n2st::print_msg "Development test to validate that the git checkout operation was succesfull (pre)."
+
+        # (Priority) ToDo: on task end >> delete next bloc ↓↓
+        git status
+        git branch --list --allo
+
         test "${DN_PROJECT_GIT_NAME}" == "dockerized-norlab-project-mock" || n2st::print_msg_error_and_exit "${DN_PROJECT_GIT_NAME} != dockerized-norlab-project-mock"
         test "${DN_PROJECT_DEPLOY_REPO_BRANCH}" == "dev" || n2st::print_msg_error_and_exit "${DN_PROJECT_DEPLOY_REPO_BRANCH} != dev"
         test "$( basename $( git remote get-url origin ) .git )" == "dockerized-norlab-project-mock" || n2st::print_msg_error_and_exit "'git remote get-url origin' should point to  dockerized-norlab-project-mock but it point to $( git remote get-url origin )"

--- a/dockerized-norlab-images/core-images/dn-project/project-deploy/Dockerfile
+++ b/dockerized-norlab-images/core-images/dn-project/project-deploy/Dockerfile
@@ -50,15 +50,16 @@ WORKDIR ${DN_PROJECT_PATH}
 # - DN_PROJECT_PATH: /ros2_ws/src/dockerized-norlab-project-mock
 RUN <<EOF
     if [[ "${DN_DEV_TESTS}" == "true" ]]; then
-        # Development test to validate that the git checkout operation was succesfull (pre)
-        # mock_file.txt only exist on the dev branch
-        tree -L 2 -a "${DN_PROJECT_PATH}"
-        {
-            test "${DN_PROJECT_GIT_NAME}" == "dockerized-norlab-project-mock" && \
-            test "${DN_PROJECT_DEPLOY_REPO_BRANCH}" == "dev" && \
-            test "$(git branch --show-current)" == "main" && \
-            test ! -f "src/mock_file.txt" ;
-        } || exit 1
+        n2st::print_msg "Development test to validate that the git checkout operation was succesfull (pre)."
+        test "${DN_PROJECT_GIT_NAME}" == "dockerized-norlab-project-mock" || n2st::print_msg_error_and_exit "${DN_PROJECT_GIT_NAME} != dockerized-norlab-project-mock"
+        test "${DN_PROJECT_DEPLOY_REPO_BRANCH}" == "dev" || n2st::print_msg_error_and_exit "${DN_PROJECT_DEPLOY_REPO_BRANCH} != dev"
+        test "$( basename $( git remote get-url origin ) .git )" == "dockerized-norlab-project-mock" || n2st::print_msg_error_and_exit "'git remote get-url origin' should point to  dockerized-norlab-project-mock but it point to $( git remote get-url origin )"
+        test "$( basename $( git rev-parse --show-toplevel ) )" == "dockerized-norlab-project-mock" || n2st::print_msg_error_and_exit "'git rev-parse --show-toplevel' should point to  dockerized-norlab-project-mock but it point to $( git rev-parse --show-toplevel )"
+        test "$(git branch --show-current)" == "main" || n2st::print_msg_error_and_exit "$(git branch --show-current) != main"
+        test ! -f "src/mock_file.txt" || n2st::print_msg_error_and_exit "mock_file.txt should only exist on the dev branch"
+        echo
+        tree -L 2 -a -hug "${DN_PROJECT_PATH}"
+        echo
     fi
 EOF
 
@@ -92,11 +93,12 @@ EOF
 
 RUN <<EOF
     if [[ "${DN_DEV_TESTS}" == "true" ]]; then
-        # Development test to validate that the git checkout operation was succesfull (post)
-        {
-            test "$(git branch --show-current)" == "dev" && \
-            test -f "src/mock_file.txt" ;
-        } || exit 1
+        n2st::print_msg "Development test to validate that the git checkout operation was succesfull (post)"
+        test "$(git branch --show-current)" == "dev" || n2st::print_msg_error_and_exit "$(git branch --show-current) != dev"
+        test -f "src/mock_file.txt" || n2st::print_msg_error_and_exit "mock_file.txt should exist on the dev branch"
+        echo
+        tree -L 2 -a -hug "${DN_PROJECT_PATH}"
+        echo
     fi
 
 EOF

--- a/dockerized-norlab-images/core-images/dn-project/project-deploy/Dockerfile
+++ b/dockerized-norlab-images/core-images/dn-project/project-deploy/Dockerfile
@@ -13,6 +13,7 @@ ENV DN_PROJECT_DEPLOY_REPO_BRANCH=${DN_PROJECT_DEPLOY_REPO_BRANCH:?'Build argume
 ENV DN_PROJECT_SERVICE=project-deploy
 ENV DN_PROJECT_SERVICE_DIR=/dockerized-norlab/project/${DN_PROJECT_SERVICE}
 
+ARG BUILDKIT_CONTEXT_KEEP_GIT_DIR=1
 ARG DN_DEV_TESTS=${DN_DEV_TESTS:-false}
 
 RUN <<EOF
@@ -25,6 +26,7 @@ RUN <<EOF
         test -n ${DN_PROJECT_PATH:?'Env variable need to be set and non-empty.'} && \
         test -d ${DN_PROJECT_PATH} && \
         test -n ${DN_DEV_WORKSPACE:?'Env variable need to be set and non-empty.'} && \
+        test -d ${DN_DEV_WORKSPACE} && \
         test -n ${DN_PROJECT_GIT_NAME:?'Env variable need to be set and non-empty.'} && \
         test -n ${DN_PROJECT_GIT_DOMAIN:?'Env variable need to be set and non-empty.'} && \
         test -n ${DN_PROJECT_DEPLOY_REPO_BRANCH:?'Env variable need to be set and non-empty.'} ;
@@ -43,7 +45,8 @@ ENV PYTHONUNBUFFERED=0
 # whether it's a personal computer, a robot or a CI server its safer and easier to manage to
 # delegate the responsibility of secret management to the user.
 WORKDIR "${DN_DEV_WORKSPACE}/src"
-COPY --chown=${DN_PROJECT_USER} --from=context-dn-project-local-src-path . ${DN_PROJECT_GIT_NAME}
+#COPY --chown=${DN_PROJECT_USER} --from=context-dn-project-local-src-path . ${DN_PROJECT_GIT_NAME}
+COPY --chown="$(id -u ${DN_PROJECT_USER}):$(id -g ${DN_PROJECT_USER})" --from=context-dn-project-local-src-path . ${DN_PROJECT_GIT_NAME}
 WORKDIR ${DN_PROJECT_PATH}
 # Dev note:
 # - DN_DEV_WORKSPACE: /ros2_ws/src
@@ -67,7 +70,9 @@ RUN <<EOF
     # ....Debug information (pre-checkout)....................................................
     n2st::print_msg "Debug information (pre-checkout)"
     tree -L 2 -aug "${DN_DEV_WORKSPACE}/src"
+    echo -e "\ncat ${DN_PROJECT_PATH}/.git"
     cat ${DN_PROJECT_PATH}/.git
+    echo
     tree -L 2 -aug ${DN_PROJECT_PATH}/.git
 
     # ....Checkout...........................................................................

--- a/tests/run_all_docker_dryrun_and_config_tests.bash
+++ b/tests/run_all_docker_dryrun_and_config_tests.bash
@@ -7,14 +7,13 @@
 #
 #
 
-_PATH_TO_SCRIPT="$(realpath "$0")"
-SCRIPT_DIR_PATH="$(dirname "${_PATH_TO_SCRIPT}")"
-TEST_DIR="$SCRIPT_DIR_PATH/tests_docker_dryrun_and_config"
-
 set -e            # exit on error
 set -o nounset    # exit on unbound variable
 set -o pipefail   # exit if errors within pipes
 
+_PATH_TO_SCRIPT="$(realpath "$0")"
+SCRIPT_DIR_PATH="$(dirname "${_PATH_TO_SCRIPT}")"
+TEST_DIR="$SCRIPT_DIR_PATH/tests_docker_dryrun_and_config"
 
 source "${SCRIPT_DIR_PATH}/../utilities/norlab-build-system/src/utility_scripts/nbs_run_all_test_and_dryrun_in_directory.bash" "${TEST_DIR}"
-
+exit $?

--- a/tests/run_bats_core_test_in_n2st.bash
+++ b/tests/run_bats_core_test_in_n2st.bash
@@ -15,31 +15,25 @@
 # =================================================================================================
 PARAMS="$@"
 
+set -e            # exit on error
+set -o nounset    # exit on unbound variable
+set -o pipefail   # exit if errors within pipes
+
 if [[ -z $PARAMS ]]; then
   # Set to default bats tests directory if none specified
   PARAMS="tests/tests_bats/"
 fi
 
-function n2st::run_n2st_testsing_tools(){
-  pushd "$(pwd)" >/dev/null || exit 1
-
 # ....Project root logic.........................................................................
-  DN_ROOT=$(git rev-parse --show-toplevel)
+DN_ROOT=$(git rev-parse --show-toplevel)
 
-  # ....Load environment variables from file.......................................................
-  cd "${DN_ROOT}" || exit 1
-  set -o allexport
-  source .env.dockerized-norlab-project
-  source .env.dockerized-norlab-build-system
-  set +o allexport
+# ....Load environment variables from file.......................................................
+cd "${DN_ROOT}" || exit 1
+set -o allexport
+source .env.dockerized-norlab-project
+source .env.dockerized-norlab-build-system
+set +o allexport
 
-  # ....Execute N2ST run_bats_tests_in_docker.bash.................................................
-  # shellcheck disable=SC2086
-  bash "${N2ST_PATH:?err}/tests/bats_testing_tools/run_bats_tests_in_docker.bash" $PARAMS
-
-  # ....Teardown...................................................................................
-  popd >/dev/null || exit 1
-  }
-
-n2st::run_n2st_testsing_tools
-
+# ....Execute N2ST run_bats_tests_in_docker.bash.................................................
+bash "${N2ST_PATH:?err}/tests/bats_testing_tools/run_bats_tests_in_docker.bash" $PARAMS
+exit $?

--- a/tests/tests_bats/test_docker-compose_global_yaml.bats
+++ b/tests/tests_bats/test_docker-compose_global_yaml.bats
@@ -1,0 +1,115 @@
+#!/usr/bin/env bats
+#
+# Usage in docker container
+#   $ REPO_ROOT=$(pwd) && RUN_TESTS_IN_DIR='tests'
+#   $ docker run -it --rm -v "$REPO_ROOT:/code" bats/bats:latest "$RUN_TESTS_IN_DIR"
+#
+#   Note: "/code" is the working directory in the bats official image
+#
+# bats-core ref:
+#   - https://bats-core.readthedocs.io/en/stable/tutorial.html
+#   - https://bats-core.readthedocs.io/en/stable/writing-tests.html
+#   - https://opensource.com/article/19/2/testing-bash-bats
+#       ↳ https://github.com/dmlond/how_to_bats/blob/master/test/build.bats
+#
+# Helper library: 
+#   - https://github.com/bats-core/bats-assert
+#   - https://github.com/bats-core/bats-support
+#   - https://github.com/bats-core/bats-file
+#
+
+BATS_HELPER_PATH=/usr/lib/bats
+if [[ -d ${BATS_HELPER_PATH} ]]; then
+  load "${BATS_HELPER_PATH}/bats-support/load"
+  load "${BATS_HELPER_PATH}/bats-assert/load"
+  load "${BATS_HELPER_PATH}/bats-file/load"
+  load "${SRC_CODE_PATH}/${N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH}/bats_helper_functions"
+  #load "${BATS_HELPER_PATH}/bats-detik/load" # << Kubernetes support
+else
+  echo -e "\n[\033[1;31mERROR\033[0m] $0 path to bats-core helper library unreachable at \"${BATS_HELPER_PATH}\"!" 1>&2
+  echo '(press any key to exit)'
+  read -r -n 1
+  exit 1
+fi
+
+# ====Setup========================================================================================
+
+TESTED_FILE="docker-compose.global.yaml"
+TESTED_FILE_PATH="./dockerized-norlab-images/core-images/global/"
+
+# executed once before starting the first test (valide for all test in that file)
+setup_file() {
+  BATS_DOCKER_WORKDIR=$(pwd) && export BATS_DOCKER_WORKDIR
+
+  ## Uncomment the following for debug, the ">&3" is for printing bats msg to stdin
+  #pwd >&3 && tree -L 1 -a -hug >&3
+  #printenv >&3
+}
+
+# executed before each test
+setup() {
+  cd "${BATS_DOCKER_WORKDIR}/$TESTED_FILE_PATH" || exit 1
+#  cd "$TESTED_FILE_PATH" || exit 1
+}
+
+# ====Teardown=====================================================================================
+
+# executed after each test
+teardown() {
+  bats_print_run_env_variable_on_error
+}
+
+## executed once after finishing the last test (valide for all test in that file)
+#teardown_file() {
+#}
+
+# ====Test casses==================================================================================
+
+@test "check \"$TESTED_FILE\" service global-service-builder-config is set to multiarch › expect pass" {
+#  cat $TESTED_FILE  >&3
+
+  echo -e "\n\n
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+[DN ERROR] -> This a '${TESTED_FILE}' misconfiguration error.
+
+The MULTIARCH global-service-builder-config is muted. Its OK for developement.
+Make sure the following lines look like this for PUSH TO CI BUILD:
+
+
+  # # Note: DEV config for local build on native architecture.
+  # # Keep MUTED for push to CI build. <--
+  # global-service-builder-config:
+  #   extends:
+  #     service: global-service-builder-config-base-images
+  #   build:
+  #     platforms: !reset []
+
+  # (CRITICAL) ToDo: Release config. Keep UNMUTED for push to CI build <--
+  global-service-builder-config:
+    extends:
+      service: global-service-builder-config-base-images
+    build:
+      platforms:
+        - linux/arm64
+        - linux/amd64
+
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+\n\n"
+
+  # ....Test multiarch build config is NOT muted...................................................
+  assert_file_exist $TESTED_FILE
+  assert_file_contains "${TESTED_FILE}" "^  global-service-builder-config:$"
+  assert_file_contains "${TESTED_FILE}" "^    extends:$"
+  assert_file_contains "${TESTED_FILE}" "^      service: global-service-builder-config-base-images$"
+  assert_file_contains "${TESTED_FILE}" "^    build:$"
+  assert_file_contains "${TESTED_FILE}" "^      platforms:$"
+  assert_file_contains "${TESTED_FILE}" "^        - linux/arm64$"
+  assert_file_contains "${TESTED_FILE}" "^        - linux/amd64$"
+
+  # ....Test native build config is muted..........................................................
+  assert_file_contains "${TESTED_FILE}" "^.*#.*platforms: !reset \[\]$"
+  assert_file_not_contains "${TESTED_FILE}" "^      platforms: !reset \[\]$"
+
+
+}

--- a/utilities/tmp/README.md
+++ b/utilities/tmp/README.md
@@ -5,7 +5,9 @@
   It is needed to implement `project-deploy` cloning/copying/checkout functionalities in and out of 
   docker container.  
   For that reason, it is cloned as a full repository at runtime, not a submodule.  
-  See dir `dockerized-norlab-images/core-images/dn-project/`
-  - `dn_callback_execute_compose_pre.bash` 
-  - and `dn_callback_execute_compose_post.bash`
+  - In [dockerized-norlab-project](https://github.com/norlab-ulaval/dockerized-norlab-project), 
+    cloning and removing is manage by `setup_mock.bash` and `teardown_mock.bash` in `tests` dir.
+  - In [dockerized-norlab](https://github.com/norlab-ulaval/dockerized-norlab), its handle by 
+    `dn_callback_execute_compose_pre.bash` and `dn_callback_execute_compose_post.bash` in 
+    directory `dockerized-norlab-images/core-images/dn-project/`.
 


### PR DESCRIPTION
# Description
### Summary:

Project-deploy related improvement in relation with Dockerized-NorLab-Project implementation

Reference tasks:
- NMO-665 fix: separate DNP docker internal from super project config
- NMO-616 refactor: split user side logic from DN-project internal logic
- NMO-661 feat: High-level RLRC/DNP refactoring

---

# Checklist:

### Code related
- [x] I have made corresponding changes to the documentation (i.e.: function/class, script header, README.md)
- [x] I have commented hard-to-understand code 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes 
- [x] My commit messages follow the [conventional commits](https://www.conventionalcommits.org) specification. See `commit_msg_reference.md` in the repository root for details

### PR creation related 
- [x] My pull request `base ref` branch is set to the `dev` branch (the _build-system_ won't be triggered otherwise) 
- [x] My pull request branch is up-to-date with the `dev` branch (the _build-system_ will reject it otherwise)

### PR description related 
- [x] I have included a quick summary of the changes
- [x] I have indicated the related issue's id with `# <issue-id>` if changes are of type `fix`

 ## Note for repository admins
 ### Release PR related
- Only repository admins have the privilege to `push/merge` on the default branch (ie: `main`) and the `release` branch.
- Keep PR in `draft` mode until all the release reviewers are ready to push the release. 
- Once a PR from `release` -> `main` branch is created (not in draft mode), it triggers the _build-system_ test
- On merge to the `main` branch, it triggers the _semantic-release automation_
