### PR TITLE
Fix Docker secret management for SSH passwords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,14 @@
 # ....Dev required.................................................................................
 /utilities/tmp/dockerized-norlab-project-mock
 
-# ....DNP common...................................................................................
+# ....DNA common...................................................................................
 **/.dockerized_norlab_project/dn_container_env_variable/
 /dockerized-norlab-tools/dn_container_env_variable/
 !/dockerized-norlab-tools/dn_container_env_variable/README.md
+
+# Docker secrets
+**/secrets/*
+*.secret
 
 
 # ====General======================================================================================
@@ -33,4 +37,3 @@
 
 # ....General......................................................................................
 **/.DS_Store
-

--- a/.junie/active_plans/Task_nmo-685_phase_1_single_secret.md
+++ b/.junie/active_plans/Task_nmo-685_phase_1_single_secret.md
@@ -1,0 +1,152 @@
+# Task NMO-685 — Phase 1 Simplification Plan: Use a Single Secret for All `chpasswd` Operations
+
+References:
+- Issue: Simplify Phase 1 to use only one Docker `secret` for all three password settings (project user, root, debugger user)
+- Existing plan to adjust: `.junie/active_plans/Task_nmo-685_implementation_phase_1.md`
+- Companion plan: `.junie/active_plans/Propose_me_a_plan_to_implement_nmo-685.md`
+
+## Objective
+Replace the "three separate secrets" approach with a single Docker secret (e.g., `dna_ssh_password`) used for:
+- `echo "${DN_PROJECT_USER}:${SSH_PASSWORD}" | chpasswd`
+- `echo "root:${SSH_PASSWORD}" | chpasswd`
+- `echo "${DN_SSH_SERVER_USER}:${SSH_PASSWORD}" | chpasswd` (when debugger user is enabled)
+
+Maintain a temporary environment variable fallback for backward compatibility during migration, but prioritize the secret.
+
+## Summary of Changes
+- In documentation and code snippets, replace `ssh_user_password`, `ssh_project_user_password`, and `ssh_root_password` with a single secret: `dna_ssh_password`.
+- Adjust the `dn_install_debugging_tools.bash` snippet to read one secret and apply it to project user, root, and debugger user.
+- Update `docker-compose.dn-project.build.yaml` examples to define only one `build.secrets` entry.
+- Update the `Dockerfile` example to mount only `dna_ssh_password` via BuildKit and export it to satisfy existing preconditions.
+- Simplify the `secrets/` directory setup to a single file.
+
+## Detailed Implementation Steps
+
+### 1) Update `dn_install_debugging_tools.bash` snippet (documentation change)
+Replace the current Phase 1 snippet in `.junie/active_plans/Task_nmo-685_implementation_phase_1.md` with the following single‑secret version:
+
+```bash
+# ....Set password for users.......................................................................
+# Prefer Docker secret, fallback to env for backward compatibility
+if [[ -f /run/secrets/dna_ssh_password ]]; then
+  SSH_PASSWORD=$(cat /run/secrets/dna_ssh_password)
+else
+  SSH_PASSWORD="${DN_SSH_SERVER_USER_PASSWORD:-}"
+fi
+
+# Validate that a password is available
+if [[ -z "${SSH_PASSWORD}" ]]; then
+  echo "ERROR: SSH password not available from secret or environment" >&2
+  exit 1
+fi
+
+# Set passwords using the single secret
+echo "${DN_PROJECT_USER}:${SSH_PASSWORD}" | chpasswd
+echo "root:${SSH_PASSWORD}" | chpasswd
+
+# ....Create and setup specialized debugger user.................................................
+if [[ ${_SETUP_DEBUGGER_USER} == true ]]; then
+  useradd --gid "${DN_PROJECT_GID:?err}" --create-home "${DN_SSH_SERVER_USER}" || exit 1
+  echo "${DN_SSH_SERVER_USER}:${SSH_PASSWORD}" | chpasswd
+  # (keep the rest of the debugger user setup steps as-is)
+fi
+```
+
+Notes:
+- This preserves backward compatibility by keeping `DN_SSH_SERVER_USER_PASSWORD` as a fallback while the ecosystem migrates to secrets.
+- The precondition in `dn_install_debugging_tools.bash` currently checks `DN_SSH_SERVER_USER_PASSWORD` is non-empty. To avoid changing that check during Phase 1, we will export the variable from the secret during the Dockerfile build step (see step 3). This keeps changes minimal.
+
+### 2) Update Docker Compose for build (single secret)
+File: `dockerized-norlab-images/core-images/dn-project/docker-compose.dn-project.build.yaml`
+
+Replace the three secret IDs and sources with a single `dna_ssh_password` secret under the `project-develop-main.build.secrets` section:
+
+```yaml
+services:
+  project-develop-main:
+    build:
+      context: project-develop
+      dockerfile: Dockerfile
+      secrets:
+        - id: dna_ssh_password
+          src: ./secrets/dna_ssh_password.txt
+      args:
+        # Do not pass DN_SSH_SERVER_USER_PASSWORD via build args
+        BASE_IMAGE: ${DN_PROJECT_HUB:?err}/${DN_PROJECT_IMAGE_NAME:?err}-core
+        BASE_IMAGE_TAG: ${PROJECT_TAG:?err}
+# Build-time secrets definition is inlined above via id/src. No service-level secrets needed for Phase 1.
+```
+
+### 3) Update the project-develop Dockerfile usage (BuildKit secret mount)
+File: `dockerized-norlab-images/core-images/dn-project/project-develop/Dockerfile`
+
+- Remove the default password value and keep the ARG (optional) without default for legacy builds:
+
+```dockerfile
+# Remove this line completely:
+# ARG DN_SSH_SERVER_USER_PASSWORD=*****
+
+# Optionally keep (no default):
+ARG DN_SSH_SERVER_USER_PASSWORD
+```
+
+- Mount the single secret and export it to satisfy the precondition check before sourcing the setup script:
+
+```dockerfile
+RUN --mount=type=secret,id=dna_ssh_password,required=1 \
+    export DN_SSH_SERVER_USER_PASSWORD="$(cat /run/secrets/dna_ssh_password)" && \
+    source ./dn_install_debugging_tools.bash && \
+    rm -f ./dn_install_debugging_tools.bash
+```
+
+Rationale:
+- The script currently checks that `DN_SSH_SERVER_USER_PASSWORD` is set. Exporting it from the secret keeps the script unchanged while enabling secret-based provisioning.
+
+### 4) Secrets directory setup (single file)
+
+```bash
+# Create secrets directory (add to .gitignore)
+mkdir -p secrets/
+
+# Generate one strong password for Phase 1
+openssl rand -base64 32 > secrets/dna_ssh_password.txt
+
+# Secure the secret
+chmod 600 secrets/dna_ssh_password.txt
+```
+
+### 5) .gitignore update (unchanged from prior plan)
+
+```gitignore
+# Docker secrets
+secrets/
+*.secret
+```
+
+### 6) Verification steps
+- Build images:
+  - `dna build project-develop` (or the equivalent build invocation used in this repo)
+  - Confirm the build succeeds without passing any password as a build arg.
+- Run container (dev config):
+  - Ensure port `2222` is mapped as per `global/docker-compose.global.yaml`.
+- Validate SSH access and passwords inside the container:
+  - Attach to the container and run: `getent shadow | grep -E "^(root|${DN_PROJECT_USER}|${DN_SSH_SERVER_USER}):"` to verify entries exist (do not print secrets).
+  - Attempt SSH login as `${DN_SSH_SERVER_USER}` on port `2222` using the generated password; confirm access.
+- Ensure no password is printed in any logs (entrypoint already avoids this).
+
+### 7) Backward compatibility and deprecation
+- During Phase 1, if `dna_ssh_password` secret is absent, operators may still pass `DN_SSH_SERVER_USER_PASSWORD` via build arg to unblock urgent builds. However, the recommended path is to use the secret.
+- Plan to remove the env fallback once all environments provide the secret (Phase 1d/Phase 2).
+
+## Acceptance Criteria
+- Only a single secret (`dna_ssh_password`) is used throughout Phase 1 documentation and examples.
+- Builds succeed with BuildKit secret mount and without leaking passwords into image history.
+- The script sets the same password for project user, root, and debugger user using the one secret.
+- No credentials are logged to stdout/stderr.
+
+## Out of Scope (Phase 2+)
+- Per-user unique passwords via multiple secrets (revisit later if needed).
+- Defaulting to SSH key-based authentication and disabling password auth by default (tracked for Phase 2).
+
+## Rollback Strategy
+- If issues arise, temporarily restore the environment variable pathway by passing `--build-arg DN_SSH_SERVER_USER_PASSWORD=...` while the single secret pipeline is fixed.

--- a/.junie/active_plans/debugging_gdbserver_implementation_plan_20250110.md
+++ b/.junie/active_plans/debugging_gdbserver_implementation_plan_20250110.md
@@ -7,7 +7,7 @@ This plan outlines the implementation of gdbserver remote debugging support for 
 ## Current State Analysis
 
 ### ✅ Already Implemented Infrastructure:
-1. **Package Installation**: `gdbserver` package installed in `dockerized-norlab-images/core-images/dependencies/Dockerfile.core` (line 66)
+1. Package installation: `gdbserver` package is installed in `dockerized-norlab-images/core-images/dependencies/Dockerfile.core`
 2. **Port Configuration**: `DN_GDB_SERVER_PORT` environment variable set to 7777 in project-develop Dockerfile
 3. **Port Exposure**: Container exposes port 7777 in Dockerfile
 4. **Port Mapping**: Docker-compose maps host port 7777 to container port 7777
@@ -81,17 +81,17 @@ n2st::print_msg "Port configured: ${DN_GDB_SERVER_PORT}"
 
 **Documentation Header Update**:
 ```bash
-# BEFORE (line 7):
+# BEFORE:
 #   3. Installs/update debugging the necessary packages,
 
-# AFTER (line 7):
+# AFTER:
 #   3. Sets up gdbserver for remote debugging with utility scripts.
 #   4. Installs/update debugging the necessary packages,
 ```
 
 **Global Variables Documentation Update**:
 ```bash
-# Add to Global Variables section (around line 18):
+# Add to the "Global Variables" section in the script header:
 # - DN_GDB_SERVER_PORT (Read): The port for the gdbserver remote debugging.
 ```
 
@@ -263,7 +263,7 @@ Gdbserver processes killed
    Host: localhost
    Port: 2222
    Username: non-interactive-ros2
-   Password: lasagne
+   Password: *****
    Root path: /
    ```
 
@@ -485,7 +485,7 @@ docker run -it --rm \
 The containers include SSH server support for remote development:
 - **Port**: 2222 (mapped from container's 22)
 - **User**: `non-interactive-ros2` (with ROS2 environment pre-loaded)
-- **Password**: `lasagne` (configurable via `DN_SSH_SERVER_USER_PASSWORD`)
+- **Password**: `*****` (configurable via `DN_SSH_SERVER_USER_PASSWORD`)
 
 ```bash
 # Connect to running container

--- a/dockerized-norlab-images/core-images/dn-project/dn_callback_execute_compose_post.bash
+++ b/dockerized-norlab-images/core-images/dn-project/dn_callback_execute_compose_post.bash
@@ -24,6 +24,10 @@ function dn::callback_execute_compose_post() {
   test -d "${DN_PATH}/utilities/tmp/dockerized-norlab-project-mock" \
     || { n2st::print_msg_error "The directory ${DN_PATH}/utilities/tmp/dockerized-norlab-project-mock is unreachable" && return 1 ; }
 
+  # Delete mock secrets
+  local secret_file_path="${DN_PATH}/dockerized-norlab-images/core-images/dn-project/secrets/dna_ssh_password.txt"
+  rm -f "${secret_file_path}"
+
   # Delete git cloned repo
   rm -rf "${DN_PATH}/utilities/tmp/dockerized-norlab-project-mock"
 

--- a/dockerized-norlab-images/core-images/dn-project/dn_callback_execute_compose_pre.bash
+++ b/dockerized-norlab-images/core-images/dn-project/dn_callback_execute_compose_pre.bash
@@ -32,7 +32,7 @@ function dn::callback_execute_compose_pre() {
 
   # ....Mock secret...............................................................................
   # Create secrets directory (if it does not exist)
-  local secret_dir="${DN_PATH}/dockerized-norlab-images/core-images/dn-project/secrets/"
+  local secret_dir="${DN_PATH}/dockerized-norlab-images/core-images/dn-project/secrets"
   mkdir -p "${secret_dir}"
   # Generate one strong password for Phase 1
   openssl rand -base64 32 > "${secret_dir}/dna_ssh_password.txt"

--- a/dockerized-norlab-images/core-images/dn-project/dn_callback_execute_compose_pre.bash
+++ b/dockerized-norlab-images/core-images/dn-project/dn_callback_execute_compose_pre.bash
@@ -30,6 +30,16 @@ function dn::callback_execute_compose_pre() {
     "${DN_PATH}/utilities/tmp/dockerized-norlab-project-mock" \
     || { n2st::print_msg_error "Could not clone dockerized-norlab-project-mock" && return 1 ;}
 
+  # ....Mock secret...............................................................................
+  # Create secrets directory (if it does not exist)
+  local secret_dir="${DN_PATH}/dockerized-norlab-images/core-images/dn-project/secrets/"
+  mkdir -p "${secret_dir}"
+  # Generate one strong password for Phase 1
+  openssl rand -base64 32 > "${secret_dir}/dna_ssh_password.txt"
+  # Secure the secret
+  chmod 600 "${secret_dir}/dna_ssh_password.txt"
+
+
   # ....Sanity check...............................................................................
   test -d "${DN_PATH}/utilities/tmp" || { n2st::print_msg_error "The directory ${DN_PATH}/utilities/tmp is unreachable" && return 1 ;}
   test -d "${DN_PATH}/utilities/tmp/dockerized-norlab-project-mock/.git" \

--- a/dockerized-norlab-images/core-images/dn-project/docker-compose.dn-project.build.yaml
+++ b/dockerized-norlab-images/core-images/dn-project/docker-compose.dn-project.build.yaml
@@ -42,6 +42,8 @@ services:
     build:
       context: project-develop
       dockerfile: Dockerfile
+      secrets:
+        - dna_ssh_password
       pull: false # Use the local image store to execute the FROM directive
       args:
         BASE_IMAGE: ${DN_PROJECT_HUB:?err}/${DN_PROJECT_IMAGE_NAME:?err}-core
@@ -111,3 +113,8 @@ services:
     depends_on:
       - project-deploy-tester
 
+
+
+secrets:
+  dna_ssh_password:
+    file: ./secrets/dna_ssh_password.txt

--- a/dockerized-norlab-images/core-images/dn-project/project-develop/Dockerfile
+++ b/dockerized-norlab-images/core-images/dn-project/project-develop/Dockerfile
@@ -30,14 +30,14 @@ EXPOSE ${DN_GDB_SERVER_PORT}
 # ...debugging user config.........................................................................
 ARG DN_SSH_SERVER_USER=dna-non-interactive-ros2
 ENV DN_SSH_SERVER_USER=${DN_SSH_SERVER_USER}
-ARG DN_SSH_SERVER_USER_PASSWORD=lasagne
 
 
 # ....install debugging tools......................................................................
 WORKDIR /dockerized-norlab/dockerized-norlab-images/container-tools
 COPY --from=context-dn-container-tools ./dn_install_debugging_tools.bash .
 
-RUN <<EOF
+# Note: require that build secrets variable 'dna_ssh_password' be set via docker-compose
+RUN --mount=type=secret,id=dna_ssh_password,required=1 <<EOF
     # ....Pre-condition............................................................................
     n2st::print_msg "Pre-condition checks..."
     {
@@ -52,8 +52,13 @@ RUN <<EOF
     } || n2st::print_msg_error_and_exit "Failed pre-condition checks!"
 
     # ....Install debugging tools..................................................................
-    source ./dn_install_debugging_tools.bash || exit 1
-    rm -f ./dn_install_debugging_tools.bash
+    export DN_SSH_SERVER_USER_PASSWORD="$(cat /run/secrets/dna_ssh_password)"
+    if [[ -n "${DN_SSH_SERVER_USER_PASSWORD}" ]]; then
+        source ./dn_install_debugging_tools.bash || exit 1
+        rm -f ./dn_install_debugging_tools.bash
+    else
+      n2st::print_msg_error_and_exit "SSH passwords not available from secrets."
+    fi
 
     # ....Sanity check.............................................................................
     test -f /etc/ssh/sshd_config_dockerized_norlab_openssh_server || exit 1


### PR DESCRIPTION
# Description
### Summary:
- Replaced legacy SSH password logic with Docker secrets.
- Updated Dockerfile and Docker Compose to use BuildKit secrets during the build process and ensure runtime compatibility.
- Centralized password operations under a single shared secret for simplification.

---

# Checklist:

### Code related
- [x] I have made corresponding changes to the documentation (i.e.: function/class, script header, README.md)
- [x] I have commented hard-to-understand code 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes 
- [x] My commit messages follow the [conventional commits](https://www.conventionalcommits.org) specification. See `commit_msg_reference.md` in the repository root for details

### PR creation related 
- [x] My pull request `base ref` branch is set to the `dev` branch (the _build-system_ won't be triggered otherwise) 
- [x] My pull request branch is up-to-date with the `dev` branch (the _build-system_ will reject it otherwise)

### PR description related 
- [x] I have included a quick summary of the changes
- [x] I have indicated the related issue's id with `# <issue-id>` if changes are of type `fix`

 ## Note for repository admins
 ### Release PR related
- Only repository admins have the privilege to `push/merge` on the default branch (ie: `main`) and the `release` branch.
- Keep PR in `draft` mode until all the release reviewers are ready to push the release. 
- Once a PR from `release` -> `main` branch is created (not in draft mode), it triggers the _build-system_ test
- On merge to the `main` branch, it triggers the _semantic-release automation_