### PR TITLE
Drop unsupported pytest-dotenv package

### DIFF
--- a/dockerized-norlab-images/core-images/dependencies/Dockerfile.core
+++ b/dockerized-norlab-images/core-images/dependencies/Dockerfile.core
@@ -105,17 +105,11 @@ RUN <<EOF
         pytest-env \
         pytest-instafail \
         pytest-xdist \
-        pytest-dotenv \
       || exit 1
 
     pip3 install --no-cache-dir --ignore-installed \
         pybind11 \
       || exit 1
-
-
-    # (CRITICAL) ToDo: test using pytest-dotenv in pycharm (ref task NMO-360 ﹅→ Fix the ROS environment variable not loaded in PyCharm pytest run nightmare)
-    # https://github.com/quiqua/pytest-dotenv
-    # How to get PyCharm test run working with pytest-dotenv?:  https://github.com/quiqua/pytest-dotenv/issues/10
 
     # ....X11 forwarding dev tools.................................................................
     # ref https://gist.github.com/sorny/969fe55d85c9b0035b0109a31cbcb088


### PR DESCRIPTION
# Description
### Summary:

Package `pytest-dotenv` is not maintained and `pytest-env` version 1.6.0 (which is maintained) introduce a flag that conflict with `pytest-dotenv`

Issue NMO-834

---

# Checklist:

### Code related
- [ ] I have made corresponding changes to the documentation (i.e.: function/class, script header, README.md)
- [ ] I have commented hard-to-understand code 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes 
- [x] My commit messages follow the [conventional commits](https://www.conventionalcommits.org) specification. See `commit_msg_reference.md` in the repository root for details

### PR creation related 
- [x] My pull request `base ref` branch is set to the `dev` branch (the _build-system_ won't be triggered otherwise) 
- [x] My pull request branch is up-to-date with the `dev` branch (the _build-system_ will reject it otherwise)

### PR description related 
- [x] I have included a quick summary of the changes
- [ ] I have indicated the related issue's id with `# <issue-id>` if changes are of type `fix`

 ## Note for repository admins
 ### Release PR related
- Only repository admins have the privilege to `push/merge` on the default branch (ie: `main`) and the `release` branch.
- Keep PR in `draft` mode until all the release reviewers are ready to push the release. 
- Once a PR from `release` -> `main` branch is created (not in draft mode), it triggers the _build-system_ test
- On merge to the `main` branch, it triggers the _semantic-release automation_